### PR TITLE
Fix clang-tidy analysis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,7 +56,7 @@ Checks: >
   readability-string-compare,
   readability-uniqueptr-delete-release
 AnalyzeTemporaryDtors: true
-HeaderFilterRegex: '(?!ui_).*'
+HeaderFilterRegex: '.*'
 CheckOptions:
 - key:   cppcoreguidelines-no-malloc.Allocations
   value: '::malloc;::calloc;::posix_memalign;::_aligned_malloc;::std::aligned_alloc'
@@ -78,7 +78,7 @@ CheckOptions:
   value: '1'
 - key:   readability-simplify-boolean-expr.ChainedConditionalReturn
   value: '1'
-- key:   alalareadability-identifier-naming.NamespaceCase
+- key:   readability-identifier-naming.NamespaceCase
   value: lower_case
 - key: readability-identifier-naming.ClassCase
   value: CamelCase

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1118,7 +1118,7 @@ jobs:
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}
       shell: sh {0}
       run: |
-        cat reports/clang-tidy-report.log | grep -E 'warning: |error: '; status=$?; test $status -ne 0
+        cat reports/clang-tidy-report.log | grep -E 'warning: |error: ' | grep -v 'autogen'; status=$?; test $status -ne 0
 
     - name: Fail if PVS-Studio found warnings (Ubuntu)
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}


### PR DESCRIPTION
* Use `.*` pattern to scan all header files
* Fix typo in `.clang-tidy`
* Exclude warnings from autogenerated files with `grep`

Looks like clang-tidy's header filter does not support excluding files (see https://reviews.llvm.org/D34654). It uses `llvm::Regex` for regular expression parsing, and its syntax (https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html) does not support negation.