### PR TITLE
Update ntc-cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1118,7 +1118,7 @@ jobs:
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}
       shell: sh {0}
       run: |
-        cat reports/clang-tidy-report.log | grep -E 'warning: |error: '; status=$?; test $status -ne 0
+        cat reports/clang-tidy-report.log | grep -E 'warning: |error: ' | grep -v 'autogen'; status=$?; test $status -ne 0
 
     - name: Fail if PVS-Studio found warnings (Ubuntu)
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1118,7 +1118,7 @@ jobs:
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}
       shell: sh {0}
       run: |
-        cat reports/clang-tidy-report.log | grep -E 'warning: |error: ' | grep -v 'autogen'; status=$?; test $status -ne 0
+        cat reports/clang-tidy-report.log | grep -E 'warning: |error: '; status=$?; test $status -ne 0
 
     - name: Fail if PVS-Studio found warnings (Ubuntu)
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}


### PR DESCRIPTION
New ntc-cmake version disables warnings on headers from build
directory with marking them as system headers and contains some
other fixes.