### PR TITLE
Enhance clang-tidy usage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,7 +34,7 @@ Checks: >
   google-runtime-int,
   hicpp-noexcept-move,
   llvm-*,
-  -llvm-header-guard,
+  -llvm-include-order,
   misc-*,
   modernize-*,
   -modernize-use-trailing-return-type,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,6 +34,7 @@ Checks: >
   google-runtime-int,
   hicpp-noexcept-move,
   llvm-*,
+  -llvm-header-guard,
   -llvm-include-order,
   misc-*,
   modernize-*,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1197,7 +1197,7 @@ jobs:
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}
       shell: sh {0}
       run: |
-        cat reports/clang-tidy-report.log | grep -E 'warning: |error: ' | grep -v 'autogen'; status=$?; test $status -ne 0
+        cat reports/clang-tidy-report.log | grep -E 'warning: |error: ' | grep -v 'melon/build'; status=$?; test $status -ne 0
 
     - name: Fail if PVS-Studio found warnings (Ubuntu)
       if: ${{ matrix.config.name == 'Ubuntu Latest Clang' }}


### PR DESCRIPTION
* Exclude llvm-include-order from clang-tidy's diagnostics
* Fix handling auto-generated files